### PR TITLE
GEODE-2935: Add Events link to footer, events img to Community

### DIFF
--- a/website/content/community/index.html
+++ b/website/content/community/index.html
@@ -48,7 +48,7 @@ under the License. -->
 			</div>
 	    	<div class="col-md-4">
 	    		<h3>Dev</h3>
-	    		<p><em>If you are building contributions & modifications to Apache Geode this is the list for you.</em><p>
+	    		<p><em>If you are building contributions and modifications to Apache Geode, this is the list for you.</em><p>
 	    		<p>To subscribe, send a blank email to<br/><a href="mailto:dev-subscribe@geode.apache.org">dev-subscribe@geode.apache.org</a>.</p>
 	    		<p>You can also <a href="http://markmail.org/search/?q=list%3Aorg.apache.geode.dev+order%3Adate-backward">read the archives</a>.</p>
 			</div>
@@ -69,17 +69,18 @@ under the License. -->
     	    	<h2 class="icns-calendar"><span>Events</span></h2>
 			</div>
 		</div>
-		<div class="row">
-    	<div class="col-md-3 done">
-    	    	<h3>Watch this space for upcoming Apache Geode events! <br />
+    <div class="row">
+      <div class="col-md-4">
+        <a  href="http://www.apache.org/events/current-event.html">
+          <img src="http://www.apache.org/events/current-event-234x60.png"/>
+        </a>
+      </div>
+    	<div class="col-md-4">
+    	    	<h3>Watch this space for upcoming Apache Geode events!</h3>
+              <p><i>Want to organize an event? Subscribe to the Apache Geode Users list by sending a blank email to<br/><a href="mailto:user-subscribe@geode.apache.org">user-subscribe@geode.apache.org</a>, then email the list with your event idea!</i>
+              </p>
       </div>
     </div>
-    <div class="row">
-			<div class="col-md-3">
-				<h3>&nbsp;</h3>
-    	    	<p><i>Want to organize an event? Subscribe to the Apache Geode Users list by sending a blank email to<br/><a href="mailto:user-subscribe@geode.apache.org">user-subscribe@geode.apache.org</a>, then email the list with your event idea!</i><p>
-			</div>
-		</div>
 	</div>
 </section>
 
@@ -91,15 +92,15 @@ under the License. -->
 			</div>
 		</div>
 		<div class="row">
-    	<div class="col-md-3">
+    	<div class="col-md-4">
     	    	<h3><a target="_blank" href="http://s.apache.org/geodechat">HipChat</a></h3>
     	    	<p>Some of the Geode team hangs around this HipChat Room: <a href="http://s.apache.org/geodechat" target="_blank">http://s.apache.org/geodechat</a><p>
 		  </div>
-      <div class="col-md-3">
+      <div class="col-md-4">
         	<h3><a target="_blank" href="http://stackoverflow.com/search?q=Apache%20Geode">StackOverflow</a></h3>
         	<p>The Geode team is always ready to answer questions on <a href="http://stackoverflow.com/search?q=Apache%20Geode">StackOverflow</a><p>
       </div>
-      <div class="col-md-3">
+      <div class="col-md-4">
         	<h3><a target="_blank" href="https://www.youtube.com/channel/UCaY2q0UlWjAgEGL7uhCLs6A">Geode ClubHouse</a></h3>
         	<p>We meet every 15 days online for discussions around specific features, detailing internals and discuss on-going issues on JIRA at the Geode Clubhouse. All meetings are recorded and videos are available in our <a href="https://www.youtube.com/channel/UCaY2q0UlWjAgEGL7uhCLs6A">YouTube</a> channel.<p>
       </div>

--- a/website/layouts/footer.html
+++ b/website/layouts/footer.html
@@ -40,6 +40,7 @@
             <div class="col-md-2">
                 <ul class="nav nav-list">
                     <li class="nav-header">Apache</li>
+                    <li><a href="http://www.apache.org/events/" target="_blank">Events</a></li>
                     <li><a href="http://www.apache.org/licenses/" target="_blank">License</a></li>
                     <li><a href="http://www.apache.org/foundation/sponsorship.html" target="_blank">Sponsorship</a></li>
                     <li><a href="http://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a></li>


### PR DESCRIPTION
This adds a text-only Events link to the website footer to
accommodate the Apache TLP Website Link Checker. It
also adds the image-based Apache Events link to the
Geode Community page.