### PR TITLE
GEODE-2788: Add official Socket timeout parameter when connecting to servers/locators

### DIFF
--- a/website/content/schema/cache/cache-1.0.xsd
+++ b/website/content/schema/cache/cache-1.0.xsd
@@ -1221,6 +1221,7 @@ As of 6.5 disk-dirs is deprecated on region-attributes. Use disk-store-name inst
         </xsd:complexType>
       </xsd:element>
     </xsd:choice>
+    <xsd:attribute name="socket-connect-timeout" type="xsd:string" use="optional" />
     <xsd:attribute name="free-connection-timeout" type="xsd:string" use="optional" />
     <xsd:attribute name="load-conditioning-interval" type="xsd:string" use="optional" />
     <xsd:attribute name="min-connections" type="xsd:string" use="optional" />


### PR DESCRIPTION
Add socket-connect-timeout to the Pool attribute. This attribute is optional.

Related changes: https://github.com/apache/geode/pull/474