### PR TITLE
Adding an assemble task for travis to invoke

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,3 +102,7 @@ rat {
     'website/layouts/**',
   ]
 }
+
+task assemble {
+  description "Empty task for travis to call. Travis always invokes assemble"
+}


### PR DESCRIPTION
Travis always invokes assemble for a gradle project, apparently.