### PR TITLE
GEODE-6402: Create DOAP file for Geode

### DIFF
--- a/website/content/doap_Geode.rdf
+++ b/website/content/doap_Geode.rdf
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+  <Project rdf:about="https://geode.apache.org">
+    <created>2021-06-24</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Geode</name>
+    <homepage rdf:resource="https://geode.apache.org" />
+    <asfext:pmc rdf:resource="https://abdera.apache.org" />
+    <shortdesc>Apache Geode is a data management platform that provides real-time, consistent access to data-intensive applications throughout widely distributed cloud architectures.</shortdesc>
+    <description>Apache Geode is a data management platform that provides real-time, consistent access to data-intensive applications throughout widely distributed cloud architectures. Geode pools memory, CPU, network resources, and optionally local disk across multiple processes to manage application objects and behavior. It uses dynamic replication and data partitioning techniques to implement high availability, improved performance, scalability, and fault tolerance. In addition to being a distributed data container, Geode is an in-memory data management system that provides reliable asynchronous event notifications and guaranteed message delivery.</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/GEODE" />
+    <mailing-list rdf:resource="https://geode.apache.org/community/#mailing-lists" />
+    <download-page rdf:resource="https://geode.apache.org/releases/" />
+
+    <programming-language>Java</programming-language>
+
+    <category rdf:resource="https://projects.apache.org/category/database" />
+
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/geode.git"/>
+        <browse rdf:resource="https://gitbox.apache.org/repos/asf/geode.git"/>
+      </GitRepository>
+    </repository>
+    </Project>
+    </rdf:RDF>


### PR DESCRIPTION
I have followed the Apache guidelines to create a DOAP file for Geode project.
They recommend to store it on the top level of the project webpage, (i.e. `http://geode.apache.org/doap_Geode.rdf` ), so I think this file has to be added to `website/content` folder in this repo.

Once it is added and publicly available, it has to be added to a xml file in the `projects.apache.org` page, check "Submitting your file" section here : https://projects.apache.org/create.html

