### PR TITLE
Restore Apache Geode graphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-[<img src="https://geode.apache.org/img/apache_geode_logo.png" align="center"/>](http://geode.apache.org)
+[<img src="https://geode.apache.org/img/Apache_Geode_logo.png" align="center"/>](http://geode.apache.org)
 
 [![Build Status](https://travis-ci.org/apache/geode-site.svg?branch=master)](https://travis-ci.org/apache/geode-site) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) 
 


### PR DESCRIPTION
**What is this change?**

This change updates the README to point to active links so the image / graphic is displayed. Currently, the image / graphic appear as a broken image.

BEFORE this change (as-is)

![before](https://user-images.githubusercontent.com/12024098/150068541-9dde94f5-7c4f-411d-aba8-5647827c277f.png)

AFTER this change is merged (will-be)

![after](https://user-images.githubusercontent.com/12024098/150068568-b6f7769c-f718-495e-962d-1e4b872d77dd.png)

**Why is this change necessary?**

Having visible, crisp logos and graphics on the main README give users, consumers, and contributors confidence they are contributing to a project that is polished, maintained and kept in good order.