### PR TITLE
Fix links to mailing list archives

### DIFF
--- a/website/content/community/index.html
+++ b/website/content/community/index.html
@@ -44,26 +44,26 @@ under the License. -->
 	    		<h3>Users</h3>
 	    		<p><em>Perfect if you build apps against Apache Geode or deploy Apache Geode, and a great place to start if you have a question.</em></p>
 	    		<p>To subscribe, send a blank email to<br/><a href="mailto:user-subscribe@geode.apache.org">user-subscribe@geode.apache.org</a>.</p>
-	    		<p>You can also <a href="http://markmail.org/search/?q=list%3Aorg.apache.geode.user+order%3Adate-backward">read the archives</a>.</p>
+	    		<p>You can also <a href="https://lists.apache.org/list.html?user@geode.apache.org">read the archives</a>.</p>
 			</div>
 	    	<div class="col-md-4">
 	    		<h3>Dev</h3>
 	    		<p><em>If you are building contributions and modifications to Apache Geode, this is the list for you.</em><p>
 	    		<p>To subscribe, send a blank email to<br/><a href="mailto:dev-subscribe@geode.apache.org">dev-subscribe@geode.apache.org</a>.</p>
-	    		<p>You can also <a href="http://markmail.org/search/?q=list%3Aorg.apache.geode.dev+order%3Adate-backward">read the archives</a>.</p>
+	    		<p>You can also <a href="https://lists.apache.org/list.html?dev@geode.apache.org">read the archives</a>.</p>
 			</div>
 	    	<div class="col-md-4">
 	    		<h3>Commits</h3>
 	    		<p><em>This list receives an email whenever new code is contributed to Apache Geode.</em><p>
 	    		<p>To subscribe, send a blank email to<br/><a href="mailto:commits-subscribe@geode.apache.org">commits-subscribe@geode.apache.org</a>.</p>
-	    		<p>You can also <a href="http://markmail.org/search/?q=list%3Aorg.apache.geode.commits+order%3Adate-backward">read the archives</a>.</p>
+	    		<p>You can also <a href="https://lists.apache.org/list.html?commits@geode.apache.org">read the archives</a>.</p>
 			</div>
 		</div>
 	    	<div class="col-md-4">
 	    		<h3>Issues</h3>
 	    		<p><em>This list receives an email when an Apache Geode issue is created or updated.</em><p>
-	    		<p>To subscribe, send a blank email to<br/><a href="mailto:commits-subscribe@geode.apache.org">issues-subscribe@geode.apache.org</a>.</p>
-	    		<p>You can also <a href="http://markmail.org/search/?q=list%3Aorg.apache.geode.issues+order%3Adate-backward">read the archives</a>.</p>
+	    		<p>To subscribe, send a blank email to<br/><a href="mailto:issues-subscribe@geode.apache.org">issues-subscribe@geode.apache.org</a>.</p>
+	    		<p>You can also <a href="https://lists.apache.org/list.html?issues@geode.apache.org">read the archives</a>.</p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Links to Markmail no longer valid. Switch to lists.apache.org.