### PR TITLE
Remove Google Analytics for 404.html page 

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,16 +18,6 @@
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-61755913-1', 'auto');
-      ga('send', 'pageview');
-
-    </script>
   </head>
   <body id='404'>
     <div id='viewport'>


### PR DESCRIPTION
Remove Google Analytics for 404.html page   - AFAIK thats the last reference to Google Analytics which has all been previously removed from the website

https://geode.apache.org/404.html